### PR TITLE
feat: use a volume for containerd to share cache across runs

### DIFF
--- a/pkg/cluster/internal/providers/docker/provision.go
+++ b/pkg/cluster/internal/providers/docker/provision.go
@@ -237,6 +237,9 @@ func runArgsForNode(node *config.Node, clusterIPFamily config.ClusterIPFamily, n
 		// running kind in kind for "party tricks"
 		// (please don't depend on doing this though!)
 		"--volume", "/var",
+		// this ensures that container image cache is shared across
+		// clusters
+		"--volume", fmt.Sprintf("%s-containerd:/var/lib/containerd", name),
 		// some k8s things want to read /lib/modules
 		"--volume", "/lib/modules:/lib/modules:ro",
 	},


### PR DESCRIPTION
**What this PR does**: This PR adds a volume for `/var/lib/containerd` that allows us to persist docker image cache across KinD runs. This volume is not removed when the cluster is created because it is a named docker container (`docker rm -v` only removes anonymous volumes).

We remove this on the devenv side, but need this patch for now to create it. We may be able to upstream this later behind a CLI flag. Will have to see, but for now this two-liner works.